### PR TITLE
Added compiler options for Solaris

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -25,6 +25,10 @@ else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -std=c++11 -finline-functions -Wall
+else ifeq ($(UNAME_SYS), SunOS)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -std=c++11 -finline-functions -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
 	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes


### PR DESCRIPTION
Compiler flags needed to get mzmetrics to build on SmartOS / Illumos / Solaris. Otherwise it will die with:

```
===> Compiling mzmetrics
make[1]: Entering directory '/root/vernemq/_build/default/lib/mzmetrics/c_src'
cc -DPCPU_COUNTERS -fPIC -I /opt/local/lib/erlang/erts-9.2/include/ -I /opt/local/lib/erlang/lib/erl_interface-3.10.1/include  -c -o /root/vernemq/_build/default/lib/mzmetrics/c_src/mzmetrics_counters_no_preallocation.o /root/vernemq/_build/default/lib/mzmetrics/c_src/mzmetrics_counters_no_preallocation.c
In file included from /usr/include/iso/stdlib_iso.h:49:0,
                 from /usr/include/stdlib.h:37,
                 from /root/vernemq/_build/default/lib/mzmetrics/c_src/mzmetrics_counters_no_preallocation.c:7:
/usr/include/sys/feature_tests.h:400:2: error: #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications       require the use of c99"
 #error "Compiler or options invalid; UNIX 03 and POSIX.1-2001 applications \
```